### PR TITLE
Added multi-file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ usage: yaml-lint [options] [input source]
   -V, --version   Display application version
 ```
 
-> :point_right: Note that only _single files_ or standard input are currently
-> supported, with support for multiple files planned for a future release.
-
 ## Install
 
 Install as a project component with Composer (executable from the project's

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -122,10 +122,10 @@ try {
         // Check input file(s)
 		foreach($argPaths as $argPath) {
 			if (!file_exists($argPath)) {
-				throw new ParseException('File does not exist');
+				throw new ParseException(sprintf('File %s does not exist', $argPath));
 			}
 			if (!is_readable($argPath)) {
-				throw new ParseException('File is not readable');
+				throw new ParseException(sprintf('File %s is not readable', $argPath));
 			}
 			
 			$lintPath($argPath);

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -82,52 +82,56 @@ try {
     if (count($argPaths) < 1) {
         throw new UsageException('no input specified', EXIT_ERROR);
     }
-    if (count($argPaths) > 1) {
-        throw new UsageException('multiple input files currently unsupported', EXIT_ERROR);
-    }
+	
+	$lintPath = function($path) use ($argQuiet, $appStr) {
+		$content = file_get_contents($path);
+		if (strlen($content) < 1) {
+			throw new ParseException('Input has no content');
+		}
 
-    $argPath = $argPaths[0];
+		// Do the thing (now accommodates changes to the Yaml::parse method introduced in v3)
+		$yamlParseMethod = new ReflectionMethod('\Symfony\Component\Yaml\Yaml', 'parse');
+		$yamlParseParams = $yamlParseMethod->getParameters();
+		switch ($yamlParseParams[1]->name) {
+			case YAML_PARSE_PARAM_NAME_EXCEPTION_ON_INVALID_TYPE:
+				// Maintains original behaviour in ^2
+				Yaml::parse($content, true);
+				break;
+			case YAML_PARSE_PARAM_NAME_FLAGS:
+				// Implements same behaviour in ^3 and ^4
+				Yaml::parse($content, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+				break;
+			default:
+				// Param name unknown, fall back to the defaults
+				Yaml::parse($content);
+				break;
+		}
 
-    if ($argPath === '-') {
+		// Output app string and file path if allowed
+		if (!$argQuiet) {
+			fwrite(STDOUT, trim($appStr . ': parsing ' . $path));
+			fwrite(STDOUT, sprintf(" [ %s ]\n", _ansify('OK', ANSI_GRN)));
+		}
+	};	
+
+    if ($argPaths[0] === '-') {
         $path = 'php://stdin';
+		
+		$lintPath($path);
     } else {
-        // Check input file
-        if (!file_exists($argPath)) {
-            throw new ParseException('File does not exist');
-        }
-        if (!is_readable($argPath)) {
-            throw new ParseException('File is not readable');
-        }
-        $path = $argPath;
-    }
-    $content = file_get_contents($path);
-    if (strlen($content) < 1) {
-        throw new ParseException('Input has no content');
-    }
-
-    // Do the thing (now accommodates changes to the Yaml::parse method introduced in v3)
-    $yamlParseMethod = new ReflectionMethod('\Symfony\Component\Yaml\Yaml', 'parse');
-    $yamlParseParams = $yamlParseMethod->getParameters();
-    switch ($yamlParseParams[1]->name) {
-        case YAML_PARSE_PARAM_NAME_EXCEPTION_ON_INVALID_TYPE:
-            // Maintains original behaviour in ^2
-            Yaml::parse($content, true);
-            break;
-        case YAML_PARSE_PARAM_NAME_FLAGS:
-            // Implements same behaviour in ^3 and ^4
-            Yaml::parse($content, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
-            break;
-        default:
-            // Param name unknown, fall back to the defaults
-            Yaml::parse($content);
-            break;
+        // Check input file(s)
+		foreach($argPaths as $argPath) {
+			if (!file_exists($argPath)) {
+				throw new ParseException('File does not exist');
+			}
+			if (!is_readable($argPath)) {
+				throw new ParseException('File is not readable');
+			}
+			
+			$lintPath($argPath);
+		}
     }
 
-    // Output app string and file path if allowed
-    if (!$argQuiet) {
-        fwrite(STDOUT, trim($appStr . ': parsing ' . $argPath));
-        fwrite(STDOUT, sprintf(" [ %s ]\n", _ansify('OK', ANSI_GRN)));
-    }
     exit(EXIT_NORMAL);
 
 } catch (UsageException $e) {


### PR DESCRIPTION
parsing will stop on the first invalid yml file.

- [x] remove note about not supporting multiple files from Readme

closes https://github.com/j13k/yaml-lint/issues/3

because of the re-indent of several lines at best review with whitespaces ignored:
https://github.com/j13k/yaml-lint/pull/9/files?w=1