### PR TITLE
Linter config via XML

### DIFF
--- a/.yaml-lint.xml.dist
+++ b/.yaml-lint.xml.dist
@@ -1,7 +1,9 @@
-<rules>
+<?xml version="1.0"?>
+<yamllinter name="yaml-linter-config">
     <description>YAML Linter config.</description>
+    <quiet>false</quiet>
     <includes>
-        <path>foo.yaml</path>
-        <path>example/bar.yaml</path>
+        <path>src/foo.yaml</path>
+        <path>bar.yaml</path>
     </includes>
-</rules>
+</yamllinter>

--- a/.yaml-lint.xml.dist
+++ b/.yaml-lint.xml.dist
@@ -3,7 +3,8 @@
     <description>YAML Linter config.</description>
     <quiet>false</quiet>
     <includes>
-        <path>src/foo.yaml</path>
-        <path>bar.yaml</path>
+        <path>foo.yaml</path>
+        <path>src/Resources/config/*.yaml</path>
+        <path>/config/bar.yaml</path>
     </includes>
 </yamllinter>

--- a/.yaml-lint.xml.dist
+++ b/.yaml-lint.xml.dist
@@ -1,0 +1,7 @@
+<rules>
+    <description>YAML Linter config.</description>
+    <includes>
+        <path>foo.yaml</path>
+        <path>example/bar.yaml</path>
+    </includes>
+</rules>

--- a/.yaml-lint.xml.dist
+++ b/.yaml-lint.xml.dist
@@ -3,8 +3,10 @@
     <description>YAML Linter config.</description>
     <quiet>false</quiet>
     <includes>
-        <path>foo.yaml</path>
-        <path>src/Resources/config/*.yaml</path>
-        <path>/config/bar.yaml</path>
+        <path>src/config/*.yml</path>
+        <path>src/config/foo.yml</path>
     </includes>
+    <excludes>
+        <path>src/config/exclude.yml</path>
+    </excludes>
 </yamllinter>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ facility of the [Symfony Yaml Component](https://github.com/symfony/yaml).
 ```text
 usage: yaml-lint [options] [input source]
 
-  input source    Path to file, or "-" to read from standard input
+  input source    .yaml-lint.xml with config, Path to file, or "-" to read from standard input
 
   -q, --quiet     Restrict output to syntax errors
   -h, --help      Display this help

--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ usage: yaml-lint [options] [input source]
   -h, --help      Display this help
   -V, --version   Display application version
 ```
-
-:information_source: Note that only _single files_ or standard input are supported
-in the current stable release, `1.1.3`.
-
-:loudspeaker: Experimental support for multiple files is available in `1.1.x-dev`.
  
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         }
     ],
     "require": {
+        "ext-simplexml": "*",
         "symfony/yaml": "^2|^3|^4|^5"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "799ebb48bf1488f0a0aa20b39d47d786",
+    "content-hash": "b80e663d1072df421e8ae179c3e5b5e2",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",
@@ -230,7 +230,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-simplexml": "*"
+    },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"
 }

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -116,7 +116,7 @@ try {
 		}
 	};
 
-    // load yaml config from .yaml-lint.xml if passed
+    // load yaml linter config from xml if passed
     if ($argPaths[0] === LINTER_CONFIG_FILE) {
         if (!file_exists($argPaths[0])) {
             throw new UsageException(sprintf('Linter config %s not found', $argPaths[0]));
@@ -126,9 +126,11 @@ try {
             $argQuiet = true;
         }
         $argPaths = [];
-        foreach ($config->xpath('//includes')[0] as $path) {
+        foreach ($config->xpath('//includes/path') as $path) {
             $argPaths = $argPaths + glob($path);
         }
+
+        $argPaths = array_values(array_diff($argPaths, $config->xpath('//excludes/path')));
     }
 
     if ($argPaths[0] === '-') {

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -122,12 +122,12 @@ try {
             throw new UsageException(sprintf('Linter config %s not found', $argPaths[0]));
         }
         $config = simplexml_load_file($argPaths[0]);
-        if ($config->quiet == 'true') {
+        if ($config->{'quiet'} == 'true') {
             $argQuiet = true;
         }
         $argPaths = [];
         foreach ($config->xpath('//includes')[0] as $path) {
-            $argPaths[] = $path;
+            $argPaths = $argPaths + glob($path);
         }
     }
 

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -116,18 +116,17 @@ try {
 		}
 	};
 
-    // build yaml files to lint from .yaml-lint.xml config
+    // load yaml config from .yaml-lint.xml if passed
     if ($argPaths[0] === LINTER_CONFIG_FILE) {
-
-        if (!file_exists($argPath)) {
-            throw new UsageException(sprintf('Linter config %s not found', LINTER_CONFIG_FILE));
+        if (!file_exists($argPaths[0])) {
+            throw new UsageException(sprintf('Linter config %s not found', $argPaths[0]));
         }
-
-        $linterConfig = simplexml_load_file('.yaml-lint.xml');
-
+        $config = simplexml_load_file($argPaths[0]);
+        if ($config->quiet == 'true') {
+            $argQuiet = true;
+        }
         $argPaths = [];
-        foreach ($linterConfig->includes->path as $path) {
-            // @todo handle excludes
+        foreach ($config->xpath('//includes')[0] as $path) {
             $argPaths[] = $path;
         }
     }

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -127,10 +127,16 @@ try {
         }
         $argPaths = [];
         foreach ($config->xpath('//includes/path') as $path) {
-            $argPaths = $argPaths + glob($path);
+            if (strpos($path, '*') !== false) {
+                $argPaths = $argPaths + glob($path);
+            } else {
+                $argPaths[] = $path;
+            }
         }
-
         $argPaths = array_values(array_diff($argPaths, $config->xpath('//excludes/path')));
+        if (!count($argPaths)) {
+            throw new UsageException('Nothing to parse, include paths are empty.');
+        }
     }
 
     if ($argPaths[0] === '-') {

--- a/src/yaml-lint.php
+++ b/src/yaml-lint.php
@@ -119,6 +119,10 @@ try {
     // build yaml files to lint from .yaml-lint.xml config
     if ($argPaths[0] === LINTER_CONFIG_FILE) {
 
+        if (!file_exists($argPath)) {
+            throw new UsageException(sprintf('Linter config %s not found', LINTER_CONFIG_FILE));
+        }
+
         $linterConfig = simplexml_load_file('.yaml-lint.xml');
 
         $argPaths = [];
@@ -215,7 +219,7 @@ EOD;
             return <<<EOD
 usage: yaml-lint [options] [input source]
 
-  input source    Path to file, or "-" to read from standard input
+  input source    .yaml-lint.xml with config, Path to file, or "-" to read from standard input
 
   -q, --quiet     Restrict output to syntax errors
   -h, --help      Display this help


### PR DESCRIPTION
Added optional linter config via `.yaml-lint.xml`:

```
* <quiet> - true|false
* <includes> - Include paths, globs like src/*.yml are allowed
* <excludes> - Exclude paths, can exclude previous included path
```